### PR TITLE
feat: add ELB resource names support

### DIFF
--- a/config/app_config.tmpl
+++ b/config/app_config.tmpl
@@ -16,34 +16,33 @@ ecs_names = https://ecs.eu-de.otc.t-systems.com/v2.1/${OTC_CREDENTIALS:project_i
 dms_names = https://dms.eu-de.otc.t-systems.com/v1.0/${OTC_CREDENTIALS:project_id}/queues?include_deadletter=true
 dms_consumer_names = https://dms.eu-de.otc.t-systems.com/v1.0/${OTC_CREDENTIALS:project_id}/queues/<queue_id>/groups?include_deadletter=true
 rds_names = https://rds.eu-de.otc.t-systems.com/rds/v1/${OTC_CREDENTIALS:project_id}/instances
+elb_names = https://elb.eu-de.otc.t-systems.com/v2.0/lbaas/loadbalancers
 
 [JSON_REQUEST]
-token = {
-	"auth": {
-	"identity": {
-	"methods": [
-	"password"
-	],
-	"password": {
-	"user": {
-	"name": "${OTC_CREDENTIALS:username}",
-	"password": "${OTC_CREDENTIALS:password}",
-	"domain": {
-	"name": "${OTC_CREDENTIALS:tenant_name}"
-	}
-	}
-	}
-	},
-	"scope": {
-	"project": {
-	"id": "${OTC_CREDENTIALS:project_id}"
-	}
-	}
-	}
-	}
+token =  {
+  "auth": {
+   "identity": {
+    "methods": ["password"],
+    "password": {
+     "user": {
+      "domain": { "name": "${OTC_CREDENTIALS:tenant_name}" },
+      "name": "${OTC_CREDENTIALS:username}",
+      "password": "${OTC_CREDENTIALS:password}"
+     }
+    }
+   },
+   "scope": {
+    "project": {
+     "id": "${OTC_CREDENTIALS:project_id}"
+    }
+   }
+  }
+ }
 
 [ECS_IDS]
 
 [DMS_IDS]
 
 [RDS_IDS]
+
+[ELB_IDS]


### PR DESCRIPTION
This PR adds support for resource names for the ELB namespace.
I also found out that Cloudeye also has metrics for ELB listeners, so I just implemented a quick "fix" to skip them.
Otherwise, they would overwrite the overall metric value for the ELB.
I'm open to suggestions on how to represent them as additional metrics.

Thanks, Tiago for this exporter! It really helped me to get the ELB Cloudeye metrics into Datadog! 💯 